### PR TITLE
Fix broken image icons in recommendations list

### DIFF
--- a/index (2).html
+++ b/index (2).html
@@ -132,21 +132,27 @@
                  <h2 class="text-3xl font-bold text-white mb-6">Recommendations</h2>
                  <ul class="space-y-6">
                     <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Deploy Model 3</h3>
                             <p class="text-gray-300">The VGG16 model is robust and ready for implementation in agricultural technology applications.</p>
                         </div>
                     </li>
                     <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Address Data Imbalance</h3>
                             <p class="text-gray-300">Enhance accuracy by gathering more images for under-represented species like 'Common wheat' and 'Maize'.</p>
                         </div>
                     </li>
                      <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Fine-Tune Hyperparameters</h3>
                             <p class="text-gray-300">Further performance gains can be achieved by tuning the learning rate and number of trainable layers.</p>

--- a/presentation/Summary.html
+++ b/presentation/Summary.html
@@ -132,21 +132,27 @@
                  <h2 class="text-3xl font-bold text-white mb-6">Recommendations</h2>
                  <ul class="space-y-6">
                     <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Deploy Model 3</h3>
                             <p class="text-gray-300">The VGG16 model is robust and ready for implementation in agricultural technology applications.</p>
                         </div>
                     </li>
                     <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Address Data Imbalance</h3>
                             <p class="text-gray-300">Enhance accuracy by gathering more images for under-represented species like 'Common wheat' and 'Maize'.</p>
                         </div>
                     </li>
                      <li class="flex items-start">
-                        <span class="text-2xl brand-text-2 mr-4 mt-1">&#10148;</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="brand-text-2 mr-4 mt-1 flex-shrink-0" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                        </svg>
                         <div>
                             <h3 class="font-bold text-lg">Fine-Tune Hyperparameters</h3>
                             <p class="text-gray-300">Further performance gains can be achieved by tuning the learning rate and number of trainable layers.</p>


### PR DESCRIPTION
The recommendations list was using a unicode character that was rendering as a broken image icon in some browsers. This change replaces the unicode character with an embedded SVG icon to ensure it renders correctly.

The same fix is applied to both `index (2).html` and `presentation/Summary.html` for consistency.